### PR TITLE
Cleaned up test code to remove levels of indirection

### DIFF
--- a/pkg/gcptarget/gcptarget_test.go
+++ b/pkg/gcptarget/gcptarget_test.go
@@ -24,31 +24,8 @@ import (
 	v1 "google.golang.org/genproto/googleapis/cloud/asset/v1"
 )
 
-// match creates a match struct as would exist in a FCV constraint
-func match(opts ...func(map[string]interface{})) map[string]interface{} {
-	matchBlock := map[string]interface{}{}
-	for _, opt := range opts {
-		opt(matchBlock)
-	}
-	return matchBlock
-}
-
-// target populates the targets field inside of the match block
-func target(targets ...string) func(map[string]interface{}) {
-	return func(matchBlock map[string]interface{}) {
-		matchBlock["target"] = targettesting.StringToInterface(targets)
-	}
-}
-
-// exclude populates the exclude field inside of the match block
-func exclude(excludes ...string) func(map[string]interface{}) {
-	return func(matchBlock map[string]interface{}) {
-		matchBlock["exclude"] = targettesting.StringToInterface(excludes)
-	}
-}
-
-// forsetiAsset creates an FCV asset with the given ancestry path.
-func forsetiAsset(ancestryPath string) func(t *testing.T) interface{} {
+// asset creates an CAI asset with the given ancestry path.
+func asset(ancestryPath string) func(t *testing.T) interface{} {
 	return func(t *testing.T) interface{} {
 		return &validator.Asset{
 			AncestryPath: ancestryPath,
@@ -78,8 +55,13 @@ func (td *reviewTestData) assetTest(nameMod string) *targetHandlerTest.ReviewTes
 }
 
 func (td *reviewTestData) jsonAssetTestcase() *targetHandlerTest.ReviewTestcase {
-	assetTest := td.assetTest("json")
-	assetTest.Object = targetHandlerTest.FromJSON(fmt.Sprintf(`
+	tc := &targetHandlerTest.ReviewTestcase{
+		Name:                "json " + td.name,
+		Match:               td.match,
+		WantMatch:           td.wantMatch,
+		WantConstraintError: td.wantConstraintError,
+	}
+	tc.Object = targetHandlerTest.FromJSON(fmt.Sprintf(`
 {
   "name": "test-name",
   "asset_type": "test-asset-type",
@@ -87,13 +69,18 @@ func (td *reviewTestData) jsonAssetTestcase() *targetHandlerTest.ReviewTestcase 
   "resource": {}
 }
 `, td.ancestryPath))
-	return assetTest
+	return tc
 }
 
-func (td *reviewTestData) forsetiAssetTestcase() *targetHandlerTest.ReviewTestcase {
-	assetTest := td.assetTest("forseti")
-	assetTest.Object = forsetiAsset(td.ancestryPath)
-	return assetTest
+func (td *reviewTestData) assetTestcase() *targetHandlerTest.ReviewTestcase {
+	tc := &targetHandlerTest.ReviewTestcase{
+		Name:                "asset " + td.name,
+		Match:               td.match,
+		WantMatch:           td.wantMatch,
+		WantConstraintError: td.wantConstraintError,
+	}
+	tc.Object = asset(td.ancestryPath)
+	return tc
 }
 
 var testData = []reviewTestData{
@@ -104,165 +91,219 @@ var testData = []reviewTestData{
 	},
 	{
 		name:         "No match specified (matches anything)",
-		match:        match(),
+		match:        map[string]interface{}{},
 		ancestryPath: "organizations/123454321/folders/1221214",
 		wantMatch:    true,
 	},
 	{
-		name:         "Only match once.",
-		match:        match(target("**", "organizations/**")),
+		name: "Only match once.",
+		match: map[string]interface{}{
+			"target": []interface{}{"**", "organizations/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match org on exact ID",
-		match:        match(target("organizations/123454321")),
+		name: "Match org on exact ID",
+		match: map[string]interface{}{
+			"target": []interface{}{"organizations/123454321"},
+		},
 		ancestryPath: "organizations/123454321",
 		wantMatch:    true,
 	},
 	{
-		name:         "Does not match org for descendant match",
-		match:        match(target("organizations/123454321/**")),
+		name: "Does not match org for descendant match",
+		match: map[string]interface{}{
+			"target": []interface{}{"organizations/123454321/**"},
+		},
 		ancestryPath: "organizations/123454321",
 		wantMatch:    false,
 	},
 	{
-		name:         "No match org on close ID",
-		match:        match(target("organizations/123454321/*")),
+		name: "No match org on close ID",
+		match: map[string]interface{}{
+			"target": []interface{}{"organizations/123454321/*"},
+		},
 		ancestryPath: "organizations/1234543211",
 		wantMatch:    false,
 	},
 	{
-		name:         "Match all under org ID - folder",
-		match:        match(target("organizations/123454321/**")),
+		name: "Match all under org ID - folder",
+		match: map[string]interface{}{
+			"target": []interface{}{"organizations/123454321/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/1242511",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match all under org ID - project",
-		match:        match(target("organizations/123454321/**")),
+		name: "Match all under org ID - project",
+		match: map[string]interface{}{
+			"target": []interface{}{"organizations/123454321/**"},
+		},
 		ancestryPath: "organizations/123454321/projects/1242511",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match all under org ID - folder, project",
-		match:        match(target("organizations/123454321/**")),
+		name: "Match all under org ID - folder, project",
+		match: map[string]interface{}{
+			"target": []interface{}{"organizations/123454321/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/125896/projects/1242511",
 		wantMatch:    true,
 	},
 	{
-		name:         "No match folder on descendants",
-		match:        match(target("**/folders/1221214/**")),
+		name: "No match folder on descendants",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/folders/1221214/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214",
 		wantMatch:    false,
 	},
 	{
-		name:         "No match folder",
-		match:        match(target("**/folders/1221214/**")),
+		name: "No match folder",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/folders/1221214/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221215",
 		wantMatch:    false,
 	},
 	{
-		name:         "No match under folder",
-		match:        match(target("**/folders/1221214/**")),
+		name: "No match under folder",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/folders/1221214/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/12212144/projects/1221214",
 		wantMatch:    false,
 	},
 	{
-		name:         "Match folder in folder",
-		match:        match(target("**/folders/1221214/**")),
+		name: "Match folder in folder",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/folders/1221214/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/folders/557385378",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match project in folder",
-		match:        match(target("**/folders/1221214/**")),
+		name: "Match project in folder",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/folders/1221214/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match project",
-		match:        match(target("**/projects/557385378")),
+		name: "Match project",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/projects/557385378"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match project by ID, not number",
-		match:        match(target("**/projects/tfv-test-project")),
+		name: "Match project by ID, not number",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/projects/tfv-test-project"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/tfv-test-project",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match any project",
-		match:        match(target("**/projects/**")),
+		name: "Match any project",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/projects/**"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
 	},
 	{
-		name:         "Does not match project",
-		match:        match(target("**/projects/123245")),
+		name: "Does not match project",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/projects/123245"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    false,
 	},
 	{
-		name:         "Match project multiple",
-		match:        match(target("**/projects/9795872589", "**/projects/557385378")),
+		name: "Match project multiple",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/projects/9795872589", "**/projects/557385378"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
 	},
 	{
-		name:         "Match any project",
-		match:        match(target("**/projects/*")),
+		name: "Match any project",
+		match: map[string]interface{}{
+			"target": []interface{}{"**/projects/*"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
 	},
 	{
-		name:         "Exclude project",
-		match:        match(exclude("**/projects/557385378")),
+		name: "Exclude project",
+		match: map[string]interface{}{
+			"exclude": []interface{}{"**/projects/557385378"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    false,
 	},
 	{
-		name:         "Exclude project by ID, not number",
-		match:        match(exclude("**/projects/tfv-exclude-project")),
+		name: "Exclude project by ID, not number",
+		match: map[string]interface{}{
+			"exclude": []interface{}{"**/projects/tfv-exclude-project"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/tfv-exclude-project",
 		wantMatch:    false,
 	},
 	{
-		name:         "Exclude project multiple",
-		match:        match(exclude("**/projects/525572987", "**/projects/557385378")),
+		name: "Exclude project multiple",
+		match: map[string]interface{}{
+			"exclude": []interface{}{"**/projects/525572987", "**/projects/557385378"},
+		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    false,
 	},
 	{
-		name:         "Exclude project via wildcard on org",
-		match:        match(exclude("organizations/*/projects/557385378")),
+		name: "Exclude project via wildcard on org",
+		match: map[string]interface{}{
+			"exclude": []interface{}{"organizations/*/projects/557385378"},
+		},
 		ancestryPath: "organizations/123454321/projects/557385378",
 		wantMatch:    false,
 	},
 	{
-		name:                "invalid target CRM type",
-		match:               match(target("flubber/*")),
+		name: "invalid target CRM type",
+		match: map[string]interface{}{
+			"target": []interface{}{"flubber/*"},
+		},
 		wantConstraintError: true,
 	},
 	{
-		name:                "org after folder",
-		match:               match(target("folders/123/organizations/*")),
+		name: "org after folder",
+		match: map[string]interface{}{
+			"target": []interface{}{"folders/123/organizations/*"},
+		},
 		wantConstraintError: true,
 	},
 	{
-		name:                "org after project",
-		match:               match(target("projects/123/organizations/*")),
+		name: "org after project",
+		match: map[string]interface{}{
+			"target": []interface{}{"projects/123/organizations/*"},
+		},
 		wantConstraintError: true,
 	},
 	{
-		name:                "folder after project",
-		match:               match(target("projects/123/folders/123")),
+		name: "folder after project",
+		match: map[string]interface{}{
+			"target": []interface{}{"projects/123/folders/123"},
+		},
 		wantConstraintError: true,
 	},
 	{
-		name:                "invalid exclude CRM name",
-		match:               match(exclude("foosball/*")),
+		name: "invalid exclude CRM name",
+		match: map[string]interface{}{
+			"exclude": []interface{}{"foosball/*"},
+		},
 		wantConstraintError: true,
 	},
 	{
@@ -301,7 +342,7 @@ func TestTargetHandler(t *testing.T) {
 		testcases = append(
 			testcases,
 			tc.jsonAssetTestcase(),
-			tc.forsetiAssetTestcase(),
+			tc.assetTestcase(),
 		)
 	}
 

--- a/pkg/targettesting/targettest.go
+++ b/pkg/targettesting/targettest.go
@@ -68,14 +68,6 @@ func CreateTargetHandler(t *testing.T, target client.TargetHandler, tcs []*Revie
 	return &targetHandlerTest
 }
 
-func StringToInterface(s []string) []interface{} {
-	iface := make([]interface{}, len(s))
-	for i := range s {
-		iface[i] = s[i]
-	}
-	return iface
-}
-
 // FromJSON returns a function that will unmarshal the JSON string and handle
 // errors appropriately.
 func FromJSON(data string) func(t *testing.T) interface{} {

--- a/pkg/tftarget/tftarget_test.go
+++ b/pkg/tftarget/tftarget_test.go
@@ -21,32 +21,6 @@ import (
 	"github.com/GoogleCloudPlatform/config-validator/pkg/targettesting"
 )
 
-// match creates a match struct as would exist in a config-validator constraint
-func match(opts ...func(map[string]interface{})) map[string]interface{} {
-	var matchBlock = map[string]interface{}{}
-	matchBlock["resource_address"] = map[string]interface{}{}
-
-	for _, opt := range opts {
-		opt(matchBlock)
-	}
-
-	return matchBlock
-}
-
-// includeAddress populates the includeAddress field inside of the match block
-func includeAddress(val ...string) func(map[string]interface{}) {
-	return func(matchBlock map[string]interface{}) {
-		matchBlock["addresses"] = targettesting.StringToInterface(val)
-	}
-}
-
-// excludeAddress populates the excludeAddress field inside of the match block
-func excludeAddress(val ...string) func(map[string]interface{}) {
-	return func(matchBlock map[string]interface{}) {
-		matchBlock["excludedAddresses"] = targettesting.StringToInterface(val)
-	}
-}
-
 // reviewTestData is the base test data which will be manifested into a
 // raw JSON.
 type reviewTestData struct {
@@ -99,105 +73,137 @@ var testData = []reviewTestData{
 	},
 	{
 		name:      "Basic 2 (wildcard)",
-		match:     match(),
+		match:     map[string]interface{}{},
 		address:   "google_compute_global_forwarding_rule.test",
 		wantMatch: true,
 	},
 	{
-		name:      "Only match once.",
-		match:     match(includeAddress("**", "*.*")),
+		name: "Only match once.",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"**", "*.*"},
+		},
 		address:   "google_compute_global_forwarding_rule.test",
 		wantMatch: true,
 	},
 	{
-		name:      "Match on exact ID",
-		match:     match(includeAddress("google_compute_global_forwarding_rule.test")),
+		name: "Match on exact ID",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"google_compute_global_forwarding_rule.test"},
+		},
 		address:   "google_compute_global_forwarding_rule.test",
 		wantMatch: true,
 	},
 	{
-		name:      "Does not match address for nested module",
-		match:     match(includeAddress("google_compute_global_forwarding_rule.test")),
+		name: "Does not match address for nested module",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"google_compute_global_forwarding_rule.test"},
+		},
 		address:   "module.abc.google_compute_global_forwarding_rule.test",
 		wantMatch: false,
 	},
 	{
-		name:      "name wildcard match",
-		match:     match(includeAddress("google_compute_global_forwarding_rule.*")),
+		name: "name wildcard match",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"google_compute_global_forwarding_rule.*"},
+		},
 		address:   "google_compute_global_forwarding_rule.test",
 		wantMatch: true,
 	},
 	{
-		name:      "module wildcard match",
-		match:     match(includeAddress("**.google_compute_global_forwarding_rule.*")),
+		name: "module wildcard match",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"**.google_compute_global_forwarding_rule.*"},
+		},
 		address:   "module.abc.google_compute_global_forwarding_rule.test",
 		wantMatch: true,
 	},
 	{
-		name:      "root wildcard match",
-		match:     match(includeAddress("**.google_compute_global_forwarding_rule.*")),
+		name: "root wildcard match",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"**.google_compute_global_forwarding_rule.*"},
+		},
 		address:   "root.google_compute_global_forwarding_rule.test",
 		wantMatch: true,
 	},
 	{
-		name:      "root doesn't match module",
-		match:     match(includeAddress("module.one.google_compute_global_forwarding_rule.*")),
+		name: "root doesn't match module",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"module.one.google_compute_global_forwarding_rule.*"},
+		},
 		address:   "root.google_compute_global_forwarding_rule.test",
 		wantMatch: false,
 	},
-	// exlude tests
+	// exclude tests
 	{
-		name:      "exclude all",
-		match:     match(excludeAddress("**", "*.*")),
+		name: "exclude all",
+		match: map[string]interface{}{
+			"excludedAddresses": []interface{}{"**", "*.*"},
+		},
 		address:   "google_compute_global_forwarding_rule.test",
 		wantMatch: false,
 	},
 	{
-		name:      "exclude on exact ID",
-		match:     match(excludeAddress("google_compute_global_forwarding_rule.test")),
+		name: "exclude on exact ID",
+		match: map[string]interface{}{
+			"excludedAddresses": []interface{}{"google_compute_global_forwarding_rule.test"},
+		},
 		address:   "google_compute_global_forwarding_rule.test",
 		wantMatch: false,
 	},
 	{
-		name:      "exclude does not match org for nested module",
-		match:     match(excludeAddress("google_compute_global_forwarding_rule.test")),
+		name: "exclude does not match org for nested module",
+		match: map[string]interface{}{
+			"excludedAddresses": []interface{}{"google_compute_global_forwarding_rule.test"},
+		},
 		address:   "module.abc.google_compute_global_forwarding_rule.test",
 		wantMatch: true,
 	},
 	{
-		name:      "exclude name wildcard match",
-		match:     match(excludeAddress("google_compute_global_forwarding_rule.*")),
+		name: "exclude name wildcard match",
+		match: map[string]interface{}{
+			"excludedAddresses": []interface{}{"google_compute_global_forwarding_rule.*"},
+		},
 		address:   "google_compute_global_forwarding_rule.test",
 		wantMatch: false,
 	},
 	{
-		name:      "exclude module wildcard match",
-		match:     match(excludeAddress("**.google_compute_global_forwarding_rule.*")),
+		name: "exclude module wildcard match",
+		match: map[string]interface{}{
+			"excludedAddresses": []interface{}{"**.google_compute_global_forwarding_rule.*"},
+		},
 		address:   "module.abc.google_compute_global_forwarding_rule.test",
 		wantMatch: false,
 	},
 	// errors
 	{
-		name:                "nested spaces",
-		match:               match(includeAddress("**.* *.*")),
+		name: "nested spaces",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"**.* *.*"},
+		},
 		address:             "module.abc.google_compute_global_forwarding_rule.test",
 		wantConstraintError: true,
 	},
 	{
-		name:                "nested special characters",
-		match:               match(includeAddress("**$$")),
+		name: "nested special characters",
+		match: map[string]interface{}{
+			"addresses": []interface{}{"**$$"},
+		},
 		address:             "module.abc.google_compute_global_forwarding_rule.test",
 		wantConstraintError: true,
 	},
 	{
-		name:                "exclude error - nested spaces",
-		match:               match(excludeAddress("**. * *.*")),
+		name: "exclude error - nested spaces",
+		match: map[string]interface{}{
+			"excludedAddresses": []interface{}{"**. * *.*"},
+		},
 		address:             "module.abc.google_compute_global_forwarding_rule.test",
 		wantConstraintError: true,
 	},
 	{
-		name:                "exclude error - nested special characters",
-		match:               match(excludeAddress("**$$")),
+		name: "exclude error - nested special characters",
+		match: map[string]interface{}{
+			"excludedAddresses": []interface{}{"**$$"},
+		},
 		address:             "module.abc.google_compute_global_forwarding_rule.test",
 		wantConstraintError: true,
 	},


### PR DESCRIPTION
the `match` and `exclude` functions make each test case slightly more compact, but they don't seem to provide significant value beyond that, and they obfuscate the underlying data structure that is being tested. I would prefer to have the test cases be slightly longer but easier to understand at a glance, if that sounds good?