### PR TITLE
Added support for ancestries / excludedAncestries

### DIFF
--- a/pkg/gcptarget/gcptarget.go
+++ b/pkg/gcptarget/gcptarget.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package gcptarget is a constraint framework target for FCV to use for integrating with the opa constraint framework.
+// Package gcptarget is a constraint framework target for config-validator to use for integrating with the opa constraint framework.
 package gcptarget
 
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"text/template"
@@ -27,7 +29,6 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
-	"github.com/pkg/errors"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -35,7 +36,7 @@ import (
 // Name is the target name for GCPTarget
 const Name = "validation.gcp.forsetisecurity.org"
 
-// GCPTarget is the constraint framework target for FCV
+// GCPTarget is the constraint framework target for CAI asset data
 type GCPTarget struct {
 }
 
@@ -66,6 +67,22 @@ func (g *GCPTarget) MatchSchema() apiextensions.JSONSchemaProps {
 					},
 				},
 			},
+			"ancestries": {
+				Type: "array",
+				Items: &apiextensions.JSONSchemaPropsOrArray{
+					Schema: &apiextensions.JSONSchemaProps{
+						Type: "string",
+					},
+				},
+			},
+			"excludedAncestries": {
+				Type: "array",
+				Items: &apiextensions.JSONSchemaPropsOrArray{
+					Schema: &apiextensions.JSONSchemaProps{
+						Type: "string",
+					},
+				},
+			},
 		},
 	}
 }
@@ -82,7 +99,7 @@ func (g *GCPTarget) Library() *template.Template {
 
 // ProcessData implements client.TargetHandler
 func (g *GCPTarget) ProcessData(obj interface{}) (bool, string, interface{}, error) {
-	return false, "", nil, errors.Errorf("Storing data for referential constraint eval is not supported at this time.")
+	return false, "", nil, errors.New("Storing data for referential constraint eval is not supported at this time.")
 }
 
 // HandleReview implements client.TargetHandler
@@ -148,17 +165,17 @@ func (g *GCPTarget) HandleReview(obj interface{}) (bool, interface{}, error) {
 			resourceTypes++
 		}
 		if resourceTypes > 1 {
-			return false, nil, errors.Errorf("malformed asset has more than one of: resource, iam policy, org policy, access context policy: %v", asset)
+			return false, nil, fmt.Errorf("malformed asset has more than one of: resource, iam policy, org policy, access context policy: %v", asset)
 		}
 		return true, asset, nil
 	}
 	return false, nil, nil
 }
 
-// handleAsset handles input from FCV assets as received via the gRPC interface.
+// handleAsset handles input from CAI assets as received via the gRPC interface.
 func (g *GCPTarget) handleAsset(asset *validator.Asset) (bool, interface{}, error) {
 	if asset.Resource == nil {
-		return false, nil, errors.Errorf("forseti asset's resource field is nil %s", asset)
+		return false, nil, fmt.Errorf("CAI asset's resource field is nil %s", asset)
 	}
 	asset2.CleanStructValue(asset.Resource.Data)
 	m := &jsonpb.Marshaler{
@@ -166,12 +183,12 @@ func (g *GCPTarget) handleAsset(asset *validator.Asset) (bool, interface{}, erro
 	}
 	var buf bytes.Buffer
 	if err := m.Marshal(&buf, asset); err != nil {
-		return false, nil, errors.Wrapf(err, "marshalling to json with asset %s: %v", asset.Name, asset)
+		return false, nil, fmt.Errorf("marshalling to json with asset %s: %v. %w", asset.Name, asset, err)
 	}
 	var f interface{}
 	err := json.Unmarshal(buf.Bytes(), &f)
 	if err != nil {
-		return false, nil, errors.Wrapf(err, "marshalling from json with asset %s: %v", asset.Name, asset)
+		return false, nil, fmt.Errorf("marshalling from json with asset %s: %v. %w", asset.Name, asset, err)
 	}
 	return true, f, nil
 }
@@ -226,12 +243,12 @@ func checkPathGlob(expression string) error {
 		switch {
 		case item == organization:
 			if state != stateStart {
-				return errors.Errorf("unexpected %s element %d in %s", item, i, expression)
+				return fmt.Errorf("unexpected %s element %d in %s", item, i, expression)
 			}
 			state = stateFolder
 		case item == folder:
 			if state != stateStart && state != stateFolder {
-				return errors.Errorf("unexpected %s element %d in %s", item, i, expression)
+				return fmt.Errorf("unexpected %s element %d in %s", item, i, expression)
 			}
 			state = stateFolder
 		case item == project:
@@ -241,7 +258,7 @@ func checkPathGlob(expression string) error {
 		case numberRegex.MatchString(item):
 		case state == stateProject && projectIDRegex.MatchString(item):
 		default:
-			return errors.Errorf("unexpected item %s element %d in %s", item, i, expression)
+			return fmt.Errorf("unexpected item %s element %d in %s", item, i, expression)
 		}
 	}
 	return nil
@@ -250,7 +267,7 @@ func checkPathGlob(expression string) error {
 func checkPathGlobs(rs []string) error {
 	for idx, r := range rs {
 		if err := checkPathGlob(r); err != nil {
-			return errors.Wrapf(err, "idx: %d", idx)
+			return fmt.Errorf("idx [%d]: %w", idx, err)
 		}
 	}
 	return nil
@@ -258,22 +275,43 @@ func checkPathGlobs(rs []string) error {
 
 // ValidateConstraint implements client.TargetHandler
 func (g *GCPTarget) ValidateConstraint(constraint *unstructured.Unstructured) error {
-	targets, found, err := unstructured.NestedStringSlice(constraint.Object, "spec", "match", "target")
-	if err != nil {
-		return errors.Errorf("invalid spec.match.target: %s", err)
-	}
-	if found {
-		if err := checkPathGlobs(targets); err != nil {
-			return errors.Wrapf(err, "invalid glob in target")
+	ancestries, ancestriesFound, ancestriesErr := unstructured.NestedStringSlice(constraint.Object, "spec", "match", "ancestries")
+	targets, targetsFound, targetsErr := unstructured.NestedStringSlice(constraint.Object, "spec", "match", "target")
+	if ancestriesFound && targetsFound {
+		return errors.New("only one of spec.match.ancestries and spec.match.target can be specified")
+	} else if ancestriesFound {
+		if ancestriesErr != nil {
+			return fmt.Errorf("invalid spec.match.ancestries: %s", ancestriesErr)
+		}
+		if ancestriesErr := checkPathGlobs(ancestries); ancestriesErr != nil {
+			return fmt.Errorf("invalid glob in spec.match.ancestries: %w", ancestriesErr)
+		}
+	} else if targetsFound {
+		if targetsErr != nil {
+			return fmt.Errorf("invalid spec.match.target: %s", targetsErr)
+		}
+		if targetsErr := checkPathGlobs(targets); targetsErr != nil {
+			return fmt.Errorf("invalid glob in spec.match.target: %w", targetsErr)
 		}
 	}
-	excludes, found, err := unstructured.NestedStringSlice(constraint.Object, "spec", "match", "exclude")
-	if err != nil {
-		return errors.Errorf("invalid spec.match.exclude: %s", err)
-	}
-	if found {
-		if err := checkPathGlobs(excludes); err != nil {
-			return errors.Wrapf(err, "invalid glob in exclude")
+
+	excludedAncestries, excludedAncestriesFound, excludedAncestriesErr := unstructured.NestedStringSlice(constraint.Object, "spec", "match", "excludedAncestries")
+	excludes, excludesFound, excludesErr := unstructured.NestedStringSlice(constraint.Object, "spec", "match", "exclude")
+	if excludedAncestriesFound && excludesFound {
+		return errors.New("only one of spec.match.excludedAncestries and spec.match.exclude can be specified")
+	} else if excludedAncestriesFound {
+		if excludedAncestriesErr != nil {
+			return fmt.Errorf("invalid spec.match.excludedAncestries: %s", excludedAncestriesErr)
+		}
+		if excludedAncestriesErr := checkPathGlobs(excludedAncestries); excludedAncestriesErr != nil {
+			return fmt.Errorf("invalid glob in spec.match.excludedAncestries: %w", excludedAncestriesErr)
+		}
+	} else if excludesFound {
+		if excludesErr != nil {
+			return fmt.Errorf("invalid spec.match.exclude: %s", excludesErr)
+		}
+		if excludesErr := checkPathGlobs(excludes); excludesErr != nil {
+			return fmt.Errorf("invalid glob in spec.match.exclude: %w", excludesErr)
 		}
 	}
 	return nil

--- a/pkg/gcptarget/gcptarget.go
+++ b/pkg/gcptarget/gcptarget.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"text/template"
@@ -27,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
 	asset2 "github.com/GoogleCloudPlatform/config-validator/pkg/asset"
 	"github.com/gogo/protobuf/jsonpb"
-	"github.com/golang/glog"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -288,7 +288,8 @@ func (g *GCPTarget) ValidateConstraint(constraint *unstructured.Unstructured) er
 			return fmt.Errorf("invalid glob in spec.match.ancestries: %w", ancestriesErr)
 		}
 	} else if targetsFound {
-		glog.Warning(
+		// TODO b/232980918: replace with zapLogger.Warn
+		log.Print(
 			"spec.match.target is deprecated and will be removed in a future release. Use spec.match.ancestries instead",
 		)
 		if targetsErr != nil {
@@ -311,7 +312,8 @@ func (g *GCPTarget) ValidateConstraint(constraint *unstructured.Unstructured) er
 			return fmt.Errorf("invalid glob in spec.match.excludedAncestries: %w", excludedAncestriesErr)
 		}
 	} else if excludesFound {
-		glog.Warning(
+		// TODO b/232980918: replace with zapLogger.Warn
+		log.Print(
 			"spec.match.exclude is deprecated and will be removed in a future release. Use spec.match.excludedAncestries instead",
 		)
 		if excludesErr != nil {

--- a/pkg/gcptarget/gcptarget.go
+++ b/pkg/gcptarget/gcptarget.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
 	asset2 "github.com/GoogleCloudPlatform/config-validator/pkg/asset"
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/golang/glog"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"

--- a/pkg/gcptarget/gcptarget.go
+++ b/pkg/gcptarget/gcptarget.go
@@ -287,6 +287,9 @@ func (g *GCPTarget) ValidateConstraint(constraint *unstructured.Unstructured) er
 			return fmt.Errorf("invalid glob in spec.match.ancestries: %w", ancestriesErr)
 		}
 	} else if targetsFound {
+		glog.Warning(
+			"spec.match.target is deprecated and will be removed in a future release. Use spec.match.ancestries instead",
+		)
 		if targetsErr != nil {
 			return fmt.Errorf("invalid spec.match.target: %s", targetsErr)
 		}
@@ -307,6 +310,9 @@ func (g *GCPTarget) ValidateConstraint(constraint *unstructured.Unstructured) er
 			return fmt.Errorf("invalid glob in spec.match.excludedAncestries: %w", excludedAncestriesErr)
 		}
 	} else if excludesFound {
+		glog.Warning(
+			"spec.match.exclude is deprecated and will be removed in a future release. Use spec.match.excludedAncestries instead",
+		)
 		if excludesErr != nil {
 			return fmt.Errorf("invalid spec.match.exclude: %s", excludesErr)
 		}

--- a/pkg/gcptarget/gcptarget_test.go
+++ b/pkg/gcptarget/gcptarget_test.go
@@ -73,6 +73,26 @@ func (td *reviewTestData) assetTestcase() *targetHandlerTest.ReviewTestcase {
 	return tc
 }
 
+func (td *reviewTestData) legacySpecMatchTestcase() *targetHandlerTest.ReviewTestcase {
+	legacyMatch := map[string]interface{}{}
+
+	if ancestries, ok := td.match["ancestries"]; ok {
+		legacyMatch["target"] = ancestries
+	}
+	if excludedAncestries, ok := td.match["excludedAncestries"]; ok {
+		legacyMatch["exclude"] = excludedAncestries
+	}
+
+	tc := &targetHandlerTest.ReviewTestcase{
+		Name:                "legacy spec match " + td.name,
+		Match:               legacyMatch,
+		WantMatch:           td.wantMatch,
+		WantConstraintError: td.wantConstraintError,
+	}
+	tc.Object = asset(td.ancestryPath)
+	return tc
+}
+
 var testData = []reviewTestData{
 	{
 		name:         "Null match object (matches anything)",
@@ -88,7 +108,7 @@ var testData = []reviewTestData{
 	{
 		name: "Only match once.",
 		match: map[string]interface{}{
-			"target": []interface{}{"**", "organizations/**"},
+			"ancestries": []interface{}{"**", "organizations/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214",
 		wantMatch:    true,
@@ -96,7 +116,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match org on exact ID",
 		match: map[string]interface{}{
-			"target": []interface{}{"organizations/123454321"},
+			"ancestries": []interface{}{"organizations/123454321"},
 		},
 		ancestryPath: "organizations/123454321",
 		wantMatch:    true,
@@ -104,7 +124,7 @@ var testData = []reviewTestData{
 	{
 		name: "Does not match org for descendant match",
 		match: map[string]interface{}{
-			"target": []interface{}{"organizations/123454321/**"},
+			"ancestries": []interface{}{"organizations/123454321/**"},
 		},
 		ancestryPath: "organizations/123454321",
 		wantMatch:    false,
@@ -112,7 +132,7 @@ var testData = []reviewTestData{
 	{
 		name: "No match org on close ID",
 		match: map[string]interface{}{
-			"target": []interface{}{"organizations/123454321/*"},
+			"ancestries": []interface{}{"organizations/123454321/*"},
 		},
 		ancestryPath: "organizations/1234543211",
 		wantMatch:    false,
@@ -120,7 +140,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match all under org ID - folder",
 		match: map[string]interface{}{
-			"target": []interface{}{"organizations/123454321/**"},
+			"ancestries": []interface{}{"organizations/123454321/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/1242511",
 		wantMatch:    true,
@@ -128,7 +148,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match all under org ID - project",
 		match: map[string]interface{}{
-			"target": []interface{}{"organizations/123454321/**"},
+			"ancestries": []interface{}{"organizations/123454321/**"},
 		},
 		ancestryPath: "organizations/123454321/projects/1242511",
 		wantMatch:    true,
@@ -136,7 +156,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match all under org ID - folder, project",
 		match: map[string]interface{}{
-			"target": []interface{}{"organizations/123454321/**"},
+			"ancestries": []interface{}{"organizations/123454321/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/125896/projects/1242511",
 		wantMatch:    true,
@@ -144,7 +164,7 @@ var testData = []reviewTestData{
 	{
 		name: "No match folder on descendants",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/folders/1221214/**"},
+			"ancestries": []interface{}{"**/folders/1221214/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214",
 		wantMatch:    false,
@@ -152,7 +172,7 @@ var testData = []reviewTestData{
 	{
 		name: "No match folder",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/folders/1221214/**"},
+			"ancestries": []interface{}{"**/folders/1221214/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221215",
 		wantMatch:    false,
@@ -160,7 +180,7 @@ var testData = []reviewTestData{
 	{
 		name: "No match under folder",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/folders/1221214/**"},
+			"ancestries": []interface{}{"**/folders/1221214/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/12212144/projects/1221214",
 		wantMatch:    false,
@@ -168,7 +188,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match folder in folder",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/folders/1221214/**"},
+			"ancestries": []interface{}{"**/folders/1221214/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/folders/557385378",
 		wantMatch:    true,
@@ -176,7 +196,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match project in folder",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/folders/1221214/**"},
+			"ancestries": []interface{}{"**/folders/1221214/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
@@ -184,7 +204,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match project",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/projects/557385378"},
+			"ancestries": []interface{}{"**/projects/557385378"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
@@ -192,7 +212,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match project by ID, not number",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/projects/tfv-test-project"},
+			"ancestries": []interface{}{"**/projects/tfv-test-project"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/tfv-test-project",
 		wantMatch:    true,
@@ -200,7 +220,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match any project",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/projects/**"},
+			"ancestries": []interface{}{"**/projects/**"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
@@ -208,7 +228,7 @@ var testData = []reviewTestData{
 	{
 		name: "Does not match project",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/projects/123245"},
+			"ancestries": []interface{}{"**/projects/123245"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    false,
@@ -216,7 +236,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match project multiple",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/projects/9795872589", "**/projects/557385378"},
+			"ancestries": []interface{}{"**/projects/9795872589", "**/projects/557385378"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
@@ -224,7 +244,7 @@ var testData = []reviewTestData{
 	{
 		name: "Match any project",
 		match: map[string]interface{}{
-			"target": []interface{}{"**/projects/*"},
+			"ancestries": []interface{}{"**/projects/*"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    true,
@@ -232,7 +252,7 @@ var testData = []reviewTestData{
 	{
 		name: "Exclude project",
 		match: map[string]interface{}{
-			"exclude": []interface{}{"**/projects/557385378"},
+			"excludedAncestries": []interface{}{"**/projects/557385378"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    false,
@@ -240,7 +260,7 @@ var testData = []reviewTestData{
 	{
 		name: "Exclude project by ID, not number",
 		match: map[string]interface{}{
-			"exclude": []interface{}{"**/projects/tfv-exclude-project"},
+			"excludedAncestries": []interface{}{"**/projects/tfv-exclude-project"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/tfv-exclude-project",
 		wantMatch:    false,
@@ -248,7 +268,7 @@ var testData = []reviewTestData{
 	{
 		name: "Exclude project multiple",
 		match: map[string]interface{}{
-			"exclude": []interface{}{"**/projects/525572987", "**/projects/557385378"},
+			"excludedAncestries": []interface{}{"**/projects/525572987", "**/projects/557385378"},
 		},
 		ancestryPath: "organizations/123454321/folders/1221214/projects/557385378",
 		wantMatch:    false,
@@ -256,7 +276,7 @@ var testData = []reviewTestData{
 	{
 		name: "Exclude project via wildcard on org",
 		match: map[string]interface{}{
-			"exclude": []interface{}{"organizations/*/projects/557385378"},
+			"excludedAncestries": []interface{}{"organizations/*/projects/557385378"},
 		},
 		ancestryPath: "organizations/123454321/projects/557385378",
 		wantMatch:    false,
@@ -264,63 +284,63 @@ var testData = []reviewTestData{
 	{
 		name: "invalid target CRM type",
 		match: map[string]interface{}{
-			"target": []interface{}{"flubber/*"},
+			"ancestries": []interface{}{"flubber/*"},
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "org after folder",
 		match: map[string]interface{}{
-			"target": []interface{}{"folders/123/organizations/*"},
+			"ancestries": []interface{}{"folders/123/organizations/*"},
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "org after project",
 		match: map[string]interface{}{
-			"target": []interface{}{"projects/123/organizations/*"},
+			"ancestries": []interface{}{"projects/123/organizations/*"},
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "folder after project",
 		match: map[string]interface{}{
-			"target": []interface{}{"projects/123/folders/123"},
+			"ancestries": []interface{}{"projects/123/folders/123"},
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "invalid exclude CRM name",
 		match: map[string]interface{}{
-			"exclude": []interface{}{"foosball/*"},
+			"excludedAncestries": []interface{}{"foosball/*"},
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "Bad target type",
 		match: map[string]interface{}{
-			"target": "organizations/*",
+			"ancestries": "organizations/*",
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "Bad target item type",
 		match: map[string]interface{}{
-			"target": []interface{}{1},
+			"ancestries": []interface{}{1},
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "Bad exclude type",
 		match: map[string]interface{}{
-			"exclude": "organizations/*",
+			"excludedAncestries": "organizations/*",
 		},
 		wantConstraintError: true,
 	},
 	{
 		name: "Bad exclude item type",
 		match: map[string]interface{}{
-			"exclude": []interface{}{1},
+			"excludedAncestries": []interface{}{1},
 		},
 		wantConstraintError: true,
 	},
@@ -333,6 +353,7 @@ func TestTargetHandler(t *testing.T) {
 			testcases,
 			tc.jsonAssetTestcase(),
 			tc.assetTestcase(),
+			tc.legacySpecMatchTestcase(),
 		)
 	}
 

--- a/pkg/gcptarget/gcptarget_test.go
+++ b/pkg/gcptarget/gcptarget_test.go
@@ -349,12 +349,12 @@ var matchTests = []reviewTestData{
 // Tests for what happens when you try to define
 // both target and ancestries or both exclude and
 // excludedAncestries
-var legacyMatchConflictTests  = []reviewTestData{
+var legacyMatchConflictTests = []reviewTestData{
 	{
 		name: "target and ancestries",
 		match: map[string]interface{}{
 			"ancestries": []interface{}{"organizations/123454321"},
-			"target": []interface{}{"organizations/123454321"},
+			"target":     []interface{}{"organizations/123454321"},
 		},
 		wantConstraintError: true,
 	},
@@ -362,7 +362,7 @@ var legacyMatchConflictTests  = []reviewTestData{
 		name: "exclude and excludedAncestries",
 		match: map[string]interface{}{
 			"excludedAncestries": []interface{}{"organizations/123454321"},
-			"exclude": []interface{}{"organizations/123454321"},
+			"exclude":            []interface{}{"organizations/123454321"},
 		},
 		wantConstraintError: true,
 	},

--- a/pkg/gcptarget/gcptarget_test.go
+++ b/pkg/gcptarget/gcptarget_test.go
@@ -93,7 +93,7 @@ func (td *reviewTestData) legacySpecMatchTestcase() *targetHandlerTest.ReviewTes
 	return tc
 }
 
-var testData = []reviewTestData{
+var matchTests = []reviewTestData{
 	{
 		name:         "Null match object (matches anything)",
 		ancestryPath: "organizations/123454321/folders/1221214",
@@ -346,14 +346,44 @@ var testData = []reviewTestData{
 	},
 }
 
+// Tests for what happens when you try to define
+// both target and ancestries or both exclude and
+// excludedAncestries
+var legacyMatchConflictTests  = []reviewTestData{
+	{
+		name: "target and ancestries",
+		match: map[string]interface{}{
+			"ancestries": []interface{}{"organizations/123454321"},
+			"target": []interface{}{"organizations/123454321"},
+		},
+		wantConstraintError: true,
+	},
+	{
+		name: "exclude and excludedAncestries",
+		match: map[string]interface{}{
+			"excludedAncestries": []interface{}{"organizations/123454321"},
+			"exclude": []interface{}{"organizations/123454321"},
+		},
+		wantConstraintError: true,
+	},
+}
+
 func TestTargetHandler(t *testing.T) {
 	var testcases []*targettesting.ReviewTestcase
-	for _, tc := range testData {
+	for _, tc := range matchTests {
 		testcases = append(
 			testcases,
 			tc.jsonAssetTestcase(),
 			tc.assetTestcase(),
 			tc.legacySpecMatchTestcase(),
+		)
+	}
+
+	for _, tc := range legacyMatchConflictTests {
+		testcases = append(
+			testcases,
+			tc.jsonAssetTestcase(),
+			tc.assetTestcase(),
 		)
 	}
 

--- a/pkg/gcptarget/library.go
+++ b/pkg/gcptarget/library.go
@@ -29,13 +29,16 @@ matching_constraints[constraint] {
 	spec := object.get(constraint, "spec", {})
 	match := object.get(spec, "match", {})
 
+	# Try ancestries / excludedAncestries first, then
+	# fall back to target / exclude.
 	# Default matcher behavior is to match everything.
-	target := object.get(match, "target", ["**"])
-	target_match := {asset.ancestry_path | path_matches(asset.ancestry_path, target[_])}
-	count(target_match) != 0
-	exclude := object.get(match, "exclude", [])
-	exclusion_match := {asset.ancestry_path | path_matches(asset.ancestry_path, exclude[_])}
-	count(exclusion_match) == 0
+	ancestries := object.get(match, "ancestries", object.get(match, "target", ["**"]))
+	ancestries_match := {asset.ancestry_path | path_matches(asset.ancestry_path, ancestries[_])}
+	count(ancestries_match) != 0
+
+	excluded_ancestries := object.get(match, "excludedAncestries", object.get(match, "exclude", []))
+	excluded_ancestries_match := {asset.ancestry_path | path_matches(asset.ancestry_path, excluded_ancestries[_])}
+	count(excluded_ancestries_match) == 0
 }
 
 # CAI Resource Types

--- a/pkg/gcv/result_test.go
+++ b/pkg/gcv/result_test.go
@@ -173,9 +173,10 @@ var conversionTestCases = []ConversionTestCase{
 					}),
 					Spec: mustAsStruct(map[string]interface{}{
 						"match": map[string]interface{}{
-							"target": []interface{}{
+							"ancestries": []interface{}{
 								"organizations/**",
 							},
+							"excludedAncestries": []interface{}{},
 						},
 						"parameters": map[string]interface{}{},
 						"severity":   "high",
@@ -218,6 +219,7 @@ var conversionTestCases = []ConversionTestCase{
 							"target": []interface{}{
 								"organizations/**",
 							},
+							"exclude": []interface{}{},
 						},
 						"parameters": map[string]interface{}{},
 						"severity":   "medium",

--- a/test/cf/constraints/cf_gcp_storage_logging_constraint.yaml
+++ b/test/cf/constraints/cf_gcp_storage_logging_constraint.yaml
@@ -22,5 +22,6 @@ metadata:
 spec:
   severity: high
   match:
-    target: ["organizations/**"]
+    ancestries: ["organizations/**"]
+    excludedAncestries: []
   parameters: {}

--- a/test/cf/constraints/gcp_storage_logging_constraint.yaml
+++ b/test/cf/constraints/gcp_storage_logging_constraint.yaml
@@ -23,4 +23,5 @@ spec:
   severity: medium
   match:
     target: ["organization/*"]
+    exclude: []
   parameters: {}


### PR DESCRIPTION
ancestries / excludedAncestries matches the naming conventions for the [TF](https://github.com/GoogleCloudPlatform/config-validator/blob/f2ac3550d4bde0a292dee1c4eb3f3a4a40df8ca7/pkg/tftarget/tftarget.go#L45) / [K8s](https://github.com/open-policy-agent/gatekeeper/blob/8d09271668aa2a12da9f445ea095341146475877/pkg/target/match_schema.go#L110) targets and eliminates confusion caused by reusing the word "target".