### PR TITLE
Sanitize ancestry before validating an asset in ReviewAsset

### DIFF
--- a/pkg/gcv/result_test.go
+++ b/pkg/gcv/result_test.go
@@ -58,6 +58,7 @@ var conversionTestCases = []ConversionTestCase{
 						},
 					},
 					"resource": map[string]interface{}{
+						"ancestors":     []interface{}{string("projects/3"), string("folders/2"), string("organizations/1")},
 						"ancestry_path": string("organizations/1/folders/2/projects/3"),
 						"asset_type":    string("storage.googleapis.com/Bucket"),
 						"name":          string("//storage.googleapis.com/my-storage-bucket"),
@@ -118,6 +119,7 @@ var conversionTestCases = []ConversionTestCase{
 						},
 					},
 					"resource": map[string]interface{}{
+						"ancestors":     []interface{}{string("projects/3"), string("folders/2"), string("organizations/1")},
 						"ancestry_path": string("organizations/1/folders/2/projects/3"),
 						"asset_type":    string("storage.googleapis.com/Bucket"),
 						"name":          string("//storage.googleapis.com/my-storage-bucket"),

--- a/pkg/gcv/validator.go
+++ b/pkg/gcv/validator.go
@@ -212,11 +212,13 @@ func NewValidatorFromContents(policyFiles []*configs.PolicyFile, policyLibrary [
 
 // ReviewAsset reviews a single asset.
 func (v *Validator) ReviewAsset(ctx context.Context, asset *validator.Asset) ([]*validator.Violation, error) {
-	if err := asset2.ValidateAsset(asset); err != nil {
+	// Sanitize the ancestry path first, so that an asset that only provides ancestors
+	// can still pass ValidateAsset.
+	if err := asset2.SanitizeAncestryPath(asset); err != nil {
 		return nil, err
 	}
 
-	if err := asset2.SanitizeAncestryPath(asset); err != nil {
+	if err := asset2.ValidateAsset(asset); err != nil {
 		return nil, err
 	}
 

--- a/pkg/gcv/validator_test.go
+++ b/pkg/gcv/validator_test.go
@@ -233,7 +233,11 @@ func testOptions() ([]string, string) {
 
 var storageAssetNoLoggingJSON = `{
   "name": "//storage.googleapis.com/my-storage-bucket",
-  "ancestry_path": "organization/1/folder/2/project/3",
+  "ancestors": [
+    "projects/3",
+    "folders/2",
+    "organizations/1"
+  ],
   "asset_type": "storage.googleapis.com/Bucket",
   "resource": {
     "version": "v1",


### PR DESCRIPTION
SanitizeAncestry fills in the ancestors / ancestry path fields if one of them is empty; ValidateAsset requires that the ancestry path is set. This means that in practice, an ancestry path must always be set. This seems unintentional, and it means that callers like terraform-validator and cft-scorecard have to work around this behavior.