### PR TITLE
fix: gen pyproto with python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ proto: proto-builder
 
 # Generate validator.proto for Python
 .PHONY: pyproto
-pyproto:
+pyproto: proto-builder
 	mkdir -p build-grpc
 	docker run \
 		-v `pwd`:/go/src/github.com/GoogleCloudPlatform/config-validator \
 		$(PROTO_DOCKER_IMAGE) \
-		python -m grpc_tools.protoc -I/proto -I./api --python_out=./build-grpc --grpc_python_out=./build-grpc ./api/validator.proto
+		python3 -m grpc_tools.protoc -I/proto -I./api --python_out=./build-grpc --grpc_python_out=./build-grpc ./api/validator.proto
 	@echo "Generated files available in ./build-grpc"
 
 .PHONY: test

--- a/build/proto/Dockerfile
+++ b/build/proto/Dockerfile
@@ -17,13 +17,14 @@
 # rather than number of layers.
 FROM golang:1.20
 
-RUN apt-get update && apt-get -y install wget unzip
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip && \
-    unzip -d /usr/local protoc-3.6.1-linux-x86_64.zip
+RUN DEBIAN_FRONTEND=noninteractive apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install wget unzip python3-pip --assume-yes
 
-RUN apt install python-pip --assume-yes
-RUN pip install --upgrade pip
-RUN pip install grpcio-tools
+ARG PROTOC_VERSION=3.6.1
+RUN wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    unzip -d /usr/local protoc-${PROTOC_VERSION}-linux-x86_64.zip
+
+RUN pip install grpcio-tools --break-system-packages
 
 # Add a common directory for .proto includes
 RUN mkdir /proto

--- a/pkg/api/validator/validator.pb.go
+++ b/pkg/api/validator/validator.pb.go
@@ -78,11 +78,12 @@ type Asset struct {
 	// Representation of the Cloud Organization access policy.
 	//
 	// Types that are assignable to AccessContextPolicy:
+	//
 	//	*Asset_AccessPolicy
 	//	*Asset_AccessLevel
 	//	*Asset_ServicePerimeter
 	AccessContextPolicy isAsset_AccessContextPolicy `protobuf_oneof:"access_context_policy"`
-	//Representation of the Cloud Organization Policy V2 set on an asset.
+	// Representation of the Cloud Organization Policy V2 set on an asset.
 	// There can be multiple V2 Organization Policies for an asset.
 	V2OrgPolicies []*orgpolicypb1.Policy `protobuf:"bytes,11,rep,name=v2_org_policies,json=v2OrgPolicies,proto3" json:"v2_org_policies,omitempty"`
 }


### PR DESCRIPTION
The `golang:1.20` base image doesn't include Python 2, update the `make pyproto` process and image to support Python 3.